### PR TITLE
Add docker-compose development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ modules.db
 bin/
 .venv
 terrareg.egg-info/
+mysql.env
+terrareg.env
+.env
+certs/*

--- a/EXAMPLE.env
+++ b/EXAMPLE.env
@@ -1,0 +1,21 @@
+# Global variables, these are used for passing configurations into the docker-compose.yml file
+DOCKER_NAME=terrareg
+DOCKER_BASE_URL=app.localhost
+
+# MySQL configurations
+ALLOW_EMPTY_PASSWORD=yes
+MYSQL_DATABASE=terrareg
+MYSQL_USER=terrareg
+MYSQL_PASSWORD=terrareg
+
+# terrareg Configuration
+SECRET_KEY=InsertHere # Change This! Generate secret key per the Docs and update this
+ADMIN_AUTHENTICATION_TOKEN=admin123 # Change This!
+
+DATABASE_URL=mysql+mysqlconnector://terrareg:terrareg@mysql:3306/terrareg # If you change the MySQL Configuration update this accordingly
+MIGRATE_DATABASE=True
+ADMIN_SESSION_EXPIRY_MINS=30
+ALLOW_MODULE_HOSTING=true
+DEBUG=true
+GIT_PROVIDER_CONFIG='[{"name": "Github", "base_url": "https://github.com/{namespace}/terraform-{provider}-{module}", "clone_url": "https://github.com/{namespace}/terraform-{provider}-{module}.git", "browse_url": "https://github.com/{namespace}/terraform-{provider}-{module}/tree/{tag}/{path}"}, {"name": "Bitbucket", "base_url": "https://bitbucket.org/{namespace}/terraform-{provider}-{module}", "clone_url": "ssh://git@bitbucket.org:{namespace}/terraform-{provider}-{module}-{provider}.git", "browse_url": "https://bitbucket.org/{namespace}/terraform-{provider}-{module}-{provider}/src/{tag}/{path}"}, {"name": "Gitlab", "base_url": "https://gitlab.com/{namespace}/terraform-{provider}-{module}", "clone_url": "ssh://git@gitlab.com:{namespace}/terraform-{provider}-{module}-{provider}.git", "browse_url": "https://gitlab.com/{namespace}/terraform-{provider}-{module}-{provider}/-/tree/{tag}/{path}"}]'
+DOMAIN_NAME=terrareg.app.localhost

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Once mkcert has been installed & configured with a local Root CA and SSL Certifi
 
 Wait a moment for everything to come online. You can then access the stack at the following URLs:
 
-terrareg - https://terrareg.app.localhost/
-phpmyadmin - https://phpmyadmin.app.localhost/
-traefik - https://traefik.app.localhost
+* terrareg - https://terrareg.app.localhost/
+* phpmyadmin - https://phpmyadmin.app.localhost/
+* traefik - https://traefik.app.localhost
 
 Because everything referencing localhost routes to 172.0.0.1 no special host file entries are required.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Provides features to aid usage and discovery of modules, providing:
 
 ## Getting started
 
-## Running with docker (Basic)
+## Running with docker
 
     # Clone the repository
     git clone https://github.com/matthewJohn/terrareg
@@ -39,7 +39,7 @@ Provides features to aid usage and discovery of modules, providing:
 
 The site can be accessed at http://localhost:5000
 
-## Running with docker (using docker-compose)
+## Running with docker-compose
 
 Using docker-compose will sping up a stack of containers including:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ This will set WSL2 to use the Certificate Authority File in Windows.
 Now install mkcert for Linux inside of your WSL2 instance. Once you've done this run the following command to see that mkcert is referencing the path on your C drive:
      mkcert -CAROOT
 
+After confirming the CAROOT path maps to your windows user (should look like /mnt/c/Users/YourUser/AppData/Local/mkcert) the CA Cert needs to be installed inside of WSL so that terraform recognizes your Local CA as Trusted. This can be done by running:
+
+    mkcert -install
+
 ### Generate Local Development SSL Certs
 
 Now that mkcert is installed and a Local CA has been generated it's time to generate an SSL Certificate for Traefik to use when proxying to the terrareg container. To do this run:
@@ -85,7 +89,7 @@ Make sure to change the following variables in the .env file before launching:
 
 ### Run the Stack
 
-Once mkcert has been installed & configured with a local Root CA and SSL Certificates it's time to start up the stack.
+Once mkcert has been installed & configured with a local CA and SSL Certificates it's time to start up the stack.
 
     docker-compose up -d
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Provides features to aid usage and discovery of modules, providing:
 
 ## Getting started
 
-## Running with docker
+## Running with docker (Basic)
 
     # Clone the repository
     git clone https://github.com/matthewJohn/terrareg
@@ -39,6 +39,63 @@ Provides features to aid usage and discovery of modules, providing:
 
 The site can be accessed at http://localhost:5000
 
+## Running with docker (using docker-compose)
+
+Using docker-compose will sping up a stack of containers including:
+
+* Traefik (SSL Proxy)
+* terrarreg
+* mysql
+* phpmyadmin
+
+This will let you run terrareg with an SSL certificate, allowing terraform cli to access modules while developing or testing the software.
+
+### Install mkcert
+
+mkcert can be installed on [Linux](https://github.com/FiloSottile/mkcert#linux), [MacOS](https://github.com/FiloSottile/mkcert#macos), [Windows](https://github.com/FiloSottile/mkcert#windows) & WSL (See notes below for WSL). After installing run the following command to create a new Local CA:
+
+    mkcert -install
+
+#### WSL Setup
+
+If you are using WSL2, install mkcert for Windows Then run the following in powershell:
+
+    setx CAROOT "$(mkcert -CAROOT)"; If ($Env:WSLENV -notlike "*CAROOT/up:*") { setx WSLENV "CAROOT/up:$Env:WSLENV" }
+
+This will set WSL2 to use the Certificate Authority File in Windows.
+
+Now install mkcert for Linux inside of your WSL2 instance. Once you've done this run the following command to see that mkcert is referencing the path on your C drive:
+     mkcert -CAROOT
+
+### Generate Local Development SSL Certs
+
+Now that mkcert is installed and a Local CA has been generated it's time to generate an SSL Certificate for Traefik to use when proxying to the terrareg container. To do this run:
+
+    mkdir -p certs
+    mkcert -cert-file certs/local-cert.pem -key-file certs/local-key.pem "app.localhost" "*.app.localhost" 
+
+### Container .env files
+
+You will find an EXAMPLE.env file that is used to configure the stack. Copy this to .env and adjust the configuration options as documented below. The key/value pairs in thie file are passed as Environment variables to the terrareg container.
+
+Make sure to change the following variables in the .env file before launching:
+
+* SECRET_KEY
+* ADMIN_AUTHENTICATION_TOKEN
+
+### Run the Stack
+
+Once mkcert has been installed & configured with a local Root CA and SSL Certificates it's time to start up the stack.
+
+    docker-compose up -d
+
+Wait a moment for everything to come online. You can then access the stack at the following URLs:
+
+terrareg - https://terrareg.app.localhost/
+phpmyadmin - https://phpmyadmin.app.localhost/
+traefik - https://traefik.app.localhost
+
+Because everything referencing localhost routes to 172.0.0.1 no special host file entries are required.
 
 ### Building locally and running
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,113 @@
+version: '3.9'
+
+services:
+
+  traefik:
+    image: traefik:v2.8
+    restart: always
+    container_name: "${DOCKER_NAME}_traefik"
+    command:
+      - --providers.docker=true
+      # Enable the API handler in insecure mode,
+      # which means that the Traefik API will be available directly
+      # on the entry point named traefik.
+      - --api.insecure=true
+      # Defines the path to the configuration file with the certificates list.
+      - --providers.file.filename=/root/.config/ssl.toml
+      # Define Traefik entry points to port [80] for http and port [443] for https.
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+    networks:
+      # Define the network on which traefik is going to operate.
+      - web
+    ports:
+      # Open traefik http [80] and https [443] ports.
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./traefik/dynamic_conf.yaml:/etc/traefik/dynamic_conf.yaml:ro
+      - ./traefik/traefik.yaml:/etc/traefik/traefik.yaml:ro
+      - ./certs:/etc/certs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${DOCKER_NAME}_traefik.rule=Host(`traefik.${DOCKER_BASE_URL}`)"
+      - "traefik.http.routers.${DOCKER_NAME}_traefik.tls=true"
+      # # Enable Traefik API handler entrypoint on http.
+      - "traefik.http.routers.${DOCKER_NAME}_traefik-http.entrypoints=web"
+      # # By default the Traefik API handler operates on the port [8080].
+      # # Define a load balancer to route the entry point to [8080].
+      - "traefik.http.services.${DOCKER_NAME}_traefik.loadbalancer.server.port=8080"
+
+  terrareg:
+    container_name: "${DOCKER_NAME}_app"
+    restart: unless-stopped
+    build: .
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${DOCKER_NAME}_app.tls=true"
+      - "traefik.http.routers.${DOCKER_NAME}_app.rule=Host(`terrareg.${DOCKER_BASE_URL}`)"
+      - "traefik.http.services.${DOCKER_NAME}_app.loadbalancer.server.port=5000"
+      - "traefik.http.routers.${DOCKER_NAME}_app.service=${DOCKER_NAME}_app"
+    depends_on:
+      - mysql
+    # environment:
+    #   - SAML2_PRIVATE_KEY
+    #   - SAML2_PUBLIC_KEY
+    env_file:
+      - ./.env
+    volumes:
+      - terrareg:/app/data
+      - ./keys:/app/keys
+      - ~/.ssh/:/root/.ssh/
+    networks:
+      web:
+
+  mysql:
+    container_name: "${DOCKER_NAME}_mysql"
+    restart: unless-stopped
+    image: docker.io/bitnami/mysql:8.0
+    # ports:
+    #   - '3306:3306'
+    volumes:
+      - 'mysql:/bitnami/mysql/data'
+    env_file:
+      - ./.env
+    healthcheck:
+      test: ['CMD', '/opt/bitnami/scripts/mysql/healthcheck.sh']
+      interval: 15s
+      timeout: 5s
+      retries: 6
+
+    networks:
+      web:
+
+  phpmyadmin:
+    container_name: "${DOCKER_NAME}_phpmyadmin"
+    restart: unless-stopped
+    image: docker.io/bitnami/phpmyadmin:5
+    depends_on:
+      - mysql
+    environment:
+      - DATABASE_HOST=mysql
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${DOCKER_NAME}_phpmyadmin.tls=true"
+      - "traefik.http.routers.${DOCKER_NAME}_phpmyadmin.rule=Host(`phpmyadmin.${DOCKER_BASE_URL}`)"
+      - "traefik.http.services.${DOCKER_NAME}_phpmyadmin.loadbalancer.server.port=8080"
+      - "traefik.http.routers.${DOCKER_NAME}_phpmyadmin.service=${DOCKER_NAME}_phpmyadmin"
+    networks:
+      web:
+      
+
+volumes:
+  terrareg:
+    driver: local
+    name: "${DOCKER_NAME}_app"
+  mysql:
+    driver: local
+    name: "${DOCKER_NAME}_mysql"
+    
+networks:
+  web:
+    external: true

--- a/traefik/dynamic_conf.yaml
+++ b/traefik/dynamic_conf.yaml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: "/etc/certs/local-cert.pem"
+      keyFile: "/etc/certs/local-key.pem"

--- a/traefik/traefik.yaml
+++ b/traefik/traefik.yaml
@@ -1,0 +1,32 @@
+global:
+  sendAnonymousUsage: false
+
+api:
+  dashboard: true
+  insecure: true
+
+providers:
+  docker:
+    endpoint: unix:///var/run/docker.sock
+    watch: true
+    exposedByDefault: false
+
+  file:
+    filename: /etc/traefik/dynamic_conf.yaml
+    watch: true
+
+log:
+  level: DEBUG
+  format: common
+
+entryPoints:
+  web:
+    address: ':80'
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+
+  websecure:
+    address: ':443'


### PR DESCRIPTION
I wanted a way to develop and test terrareg and expose it over TLS so that the terraform cli can pull down modules. By utilizing traefik & mkcert it's possible to generate a locally trusted CA and Certificates to proxy the traffic to the terrareg container, providing a functional TLS endpoint for testing.