### PR TITLE
Fix tfswitch when using Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
+RUN mkdir bin
+
 COPY LICENSE .
 COPY alembic.ini .
 COPY terrareg.py .

--- a/terrareg/module_extractor.py
+++ b/terrareg/module_extractor.py
@@ -128,7 +128,7 @@ class ModuleExtractor:
                 )
             except subprocess.CalledProcessError as exc:
                 print("An error occured whilst running tfswitch:", str(exc))
-                raise TerraformVersionSwitchError("An error occurred whilst initialising Terraform version")
+                raise TerraformVersionSwitchError(f"An error occurred whilst initialising Terraform version: {exc}")
 
             yield
         finally:
@@ -304,7 +304,7 @@ credentials "{domain_name}" {{
             tfsec=tfsec,
             terraform_graph=terraform_graph
         )
-        
+
         # Update attributes of module_version in database
         self._module_version.update_attributes(
             module_details_id=module_details.pk,
@@ -514,7 +514,7 @@ credentials "{domain_name}" {{
                     # Otherwise, break from iterations
                     break
                 extracted_description = new_description
-         
+
             return extracted_description if extracted_description else None
 
         return None


### PR DESCRIPTION
tfswitch attempts to install the `terraform` binary to `/app/bin/` but this fails because the directory doesn't exist. Add this directory to the Dockerfile.

In addition, bubble up the error which is passed to the `TerraformVersionSwitchError` exception, which helped catch this.