### PR TITLE
Log error details on failed tag import

### DIFF
--- a/terrareg/server/api/module_version_create_github_hook.py
+++ b/terrareg/server/api/module_version_create_github_hook.py
@@ -95,7 +95,7 @@ class ApiModuleVersionCreateGitHubHook(ErrorCatchingResource):
 
                     return {
                         'status': 'Error',
-                        'message': 'Tag failed to import',
+                        'message': f'Tag failed to import: {str(exc)}',
                         'tag': tag_ref
                     }, 500
                 else:


### PR DESCRIPTION
I was seeing this error (`Tag failed to import`) and struggling to understand its cause.
Printing the contents of the error helps to identify what's actually going on. In my case, incorrect github perms.

Aware that you have a particular PR name format which I'm probably not meeting but I'm not sure what it is (could be useful to have this in your `CONTRIBUTING.md`?)

Have also signed up for an account on gitlab to prevent you from having to duplicate, waiting for approval.